### PR TITLE
fix: Error from hash changes from browsing back/forward 

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -208,6 +208,8 @@ class Controller {
     // console.log('phila-vue-datafetch controller.js, handleSearchFormSubmit is running, value:', value, 'searchCategory:', searchCategory, 'this:', this);
 
     this.dataManager.resetData();
+    // Added specifically to reset the condo units not being cleared elsewhere on hash change.
+    this.resetGeocode();
 
     if(value === '' || value === null) {
       console.log('submitting blank value');

--- a/src/data-manager.js
+++ b/src/data-manager.js
@@ -526,6 +526,7 @@ class DataManager {
   resetShape() {
     this.store.commit('setShapeSearchData', null);
     this.store.commit('setShapeSearchStatus', null);
+    this.store.commit('setUnits', null);
   }
 
   resetGeocodeOnly() {
@@ -534,6 +535,7 @@ class DataManager {
     this.store.commit('setGeocodeStatus', null);
     this.store.commit('setGeocodeData', null);
     this.store.commit('setGeocodeRelated', null);
+    this.store.commit('setUnits', null);
     this.store.commit('setGeocodeInput', null);
   }
 
@@ -545,6 +547,7 @@ class DataManager {
     this.store.commit('setGeocodeStatus', null);
     this.store.commit('setGeocodeData', null);
     this.store.commit('setGeocodeRelated', null);
+    this.store.commit('setUnits', null);
     this.store.commit('setGeocodeInput', null);
 
     // reset parcels


### PR DESCRIPTION
Geocoded searches were catching an error bc previous condoUnits were not cleared from the state. CityOfPhiladelphia/property-data-explorer#297