### PR TITLE
fix: clears shapeSearch data on search form submit 

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -209,6 +209,7 @@ class Controller {
 
     this.dataManager.resetData();
     // Added specifically to reset the condo units not being cleared elsewhere on hash change.
+    this.dataManager.resetShape();
     this.resetGeocode();
 
     if(value === '' || value === null) {


### PR DESCRIPTION
Closes CityOfPhiladelphia/property-data-explorer#323