### PR TITLE
fix: Remove setUnits from resetShape to fix condo button on reverse geocode.

### DIFF
--- a/src/data-manager.js
+++ b/src/data-manager.js
@@ -526,7 +526,6 @@ class DataManager {
   resetShape() {
     this.store.commit('setShapeSearchData', null);
     this.store.commit('setShapeSearchStatus', null);
-    this.store.commit('setUnits', null);
   }
 
   resetGeocodeOnly() {


### PR DESCRIPTION
Fixes CityOfPhiladelphia/property-data-explorer#340