### PR TITLE
fix: Resets shapeSearchData to null before doing another shape search

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -550,7 +550,7 @@ class Controller {
     // this.geocode(features);
     this.store.commit('setLastSearchMethod', 'shape search');
     this.dataManager.removeShape();
-    // this.clearShapeSearch()
+    this.store.commit('setShapeSearchData', null);
     this.dataManager.resetGeocodeOnly();
 
     this.router.setRouteByShapeSearch();


### PR DESCRIPTION
Fixes and issue that was causing the condo button to stay hidden when you searched a property, clicked the button and then searched the same condo property again. 
See CityOfPhiladelphia/property-data-explorer#435